### PR TITLE
Update CVE-2017-7649.json

### DIFF
--- a/2017/7xxx/CVE-2017-7649.json
+++ b/2017/7xxx/CVE-2017-7649.json
@@ -12,11 +12,12 @@
                     "product": {
                         "product_data": [
                             {
-                                "product_name": "Kura_installer",
+                                "product_name": "Eclipse Kura Installer",
                                 "version": {
                                     "version_data": [
                                         {
-                                            "version_value": "Versions prior to 2.1.0"
+                                            "version_affected": "<",
+                                            "version_value": "2.1.0"
                                         }
                                     ]
                                 }

--- a/2017/7xxx/CVE-2017-7649.json
+++ b/2017/7xxx/CVE-2017-7649.json
@@ -12,7 +12,7 @@
                     "product": {
                         "product_data": [
                             {
-                                "product_name": "Kura",
+                                "product_name": "Kura_installer",
                                 "version": {
                                     "version_data": [
                                         {


### PR DESCRIPTION
The only element affected by this issue is the Kura Installer, not the jar files that compose the Kura distribution.